### PR TITLE
Add SetState functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ FSM_State*  GetStateAt(uint8_t index);
 // Get active state name
 const char* ActiveStateName();
 
+// Set machine to state at index. Will call every function as expected unless told otherwise
+// If is the same state as the current, it should call onEntering and onLeaving and Refresh Timeout
+void SetState (uint8_t index, bool callOnEntering = true, bool callOnLeaving = true)
+  
 // Set or modify a state timeout (preset = milliseconds)
 void SetTimeout(uint8_t index, uint32_t preset);
 

--- a/src/YA_FSM.cpp
+++ b/src/YA_FSM.cpp
@@ -315,7 +315,7 @@ uint8_t YA_FSM::GetState() const{
 }
 
 // Change to State
-void YA_FSM::SetState(uint8_t index, bool callOnEntering = true, bool callOnLeaving = true) {
+void YA_FSM::SetState(uint8_t index, bool callOnEntering, bool callOnLeaving) {
 	FSM_State* newState = GetStateAt(index);
 	// If found state at index
 	if(newState != nullptr ) {

--- a/src/YA_FSM.cpp
+++ b/src/YA_FSM.cpp
@@ -314,6 +314,27 @@ uint8_t YA_FSM::GetState() const{
 	return _currentState->index;
 }
 
+// Change to State
+void YA_FSM::SetState(uint8_t index, bool callOnEntering = true, bool callOnLeaving = true) {
+	FSM_State* newState = GetStateAt(index);
+	// If found state at index
+	if(newState != nullptr ) {
+		// Guarantee that will run OnLeaving()
+		if(_currentState->OnLeaving != nullptr && callOnLeaving)
+			_currentState->OnLeaving();
+
+		_currentState = newState;
+
+		// Guarantee that will run OnEntering()
+		if(_currentState->OnEntering != nullptr && callOnEntering)
+			_currentState->OnEntering();
+
+		// Update Enter Time
+		_currentState->enterTime = millis();
+		_currentState->timeout = false;
+	}
+}
+
 void YA_FSM::SetTimeout(uint8_t index, uint32_t preset) {
 	FSM_State* state = GetStateAt(index);
 	if(state != nullptr ){

--- a/src/YA_FSM.h
+++ b/src/YA_FSM.h
@@ -75,6 +75,7 @@ public:
 
 	uint8_t 	AddAction(uint8_t inputState, uint8_t type, bool &target, uint32_t _time=0);
 	uint8_t 	GetState() const;
+	void 		SetState(uint8_t index, bool callOnEntering = true, bool callOnLeaving = true);
 	uint8_t 	StateIndex() const;
 	uint32_t 	GetEnteringTime(uint8_t index);
 


### PR DESCRIPTION
Adding a function that will set the machine to a specific state with or without calling onEntering and onLeaving. It also refresh the timeout if the desired state is the current one.