### PR TITLE
Added an `AddTimedTransition()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,11 @@ stateMachine.AddState(STATE_LABEL, TIME_MAX, onEnterCB, onStateCB, onExitCB);
 ```
 
 ### Transition definition and trigger
-To connect two states, you need to define the transition. The trigger of transition can be performed with a bool function() or a bool variable. Also the timeout of state itself (it is a bool) can be used for triggering to next state. 
+To connect two states, you need to define the transition. The trigger of transition can be performed with a bool function(), a bool variable, or the timeout of the state itself.
 
-In order to check if a specific state has timeout call method `Timeout(state_index)`. You can also check the value of `timeout` property.
+In order to check if a specific state has exceeded its timeout, use the `AddTimedTransition()` method, which checks the `CurrentState()->timeout` bool property stored in the related struct of type [FSM_State](https://github.com/cotestatnt/YA_FSM/blob/master/src/YA_FSM.h#L15)
 
-For example in this instruction is used a **lambda function** returning the value of timout for current state (FROM_STATE_INDEX) stored in the related struct of type [FSM_State](https://github.com/cotestatnt/YA_FSM/blob/master/src/YA_FSM.h#L15)
-
-` stateMachine.AddTransition(FROM_STATE_INDEX, TO_STATE_INDEX, [](){return stateMachine.CurrentState()->timeout;} );`
+` stateMachine.AddTimedTransition(FROM_STATE_INDEX, TO_STATE_INDEX);`
 
 ### Action definition
 For each state you can define also a maximun of 64 qualified action, that will be execute when state is active causing effect to the target bool variable

--- a/src/YA_FSM.cpp
+++ b/src/YA_FSM.cpp
@@ -1,6 +1,5 @@
 #include "YA_FSM.h"
 
-
 FSM_State*  YA_FSM::CurrentState(){
 	return _currentState;
 }
@@ -266,10 +265,10 @@ bool YA_FSM::Update(){
 			}
 
 			bool _trigger = false;
-			if(actualtr->Condition == nullptr)
-				_trigger = *(actualtr->ConditionVar);
-			else if (actualtr->TimedTransition == true)
+			if (actualtr->TimedTransition == true)
 				_trigger = _currentState->timeout;
+			else if(actualtr->Condition == nullptr)
+				_trigger = *(actualtr->ConditionVar);
 			else
 				_trigger = actualtr->Condition();
 

--- a/src/YA_FSM.cpp
+++ b/src/YA_FSM.cpp
@@ -81,6 +81,21 @@ uint8_t YA_FSM::AddTransition(uint8_t inputState, uint8_t outputState, bool &con
 	return _currentTransitionIndex++;
 }
 
+uint8_t	YA_FSM::AddTimedTransition(uint8_t inputState, uint8_t outputState){
+	FSM_Transition *transition = new FSM_Transition();
+	if (_firstTransition == nullptr)
+		_firstTransition = transition;
+	else
+		_lastTransition->nextTransition = transition;
+	_lastTransition = transition;
+
+	transition->TimedTransition = true;
+	transition->InputState = inputState;
+	transition->OutputState = outputState;
+
+	return _currentTransitionIndex++;
+}
+
 
 uint8_t YA_FSM::AddAction(uint8_t inputState, uint8_t type, bool &target, uint32_t _time) {
 
@@ -253,6 +268,8 @@ bool YA_FSM::Update(){
 			bool _trigger = false;
 			if(actualtr->Condition == nullptr)
 				_trigger = *(actualtr->ConditionVar);
+			else if (actualtr->TimedTransition == true)
+				_trigger = _currentState->timeout;
 			else
 				_trigger = actualtr->Condition();
 

--- a/src/YA_FSM.h
+++ b/src/YA_FSM.h
@@ -27,6 +27,7 @@ struct FSM_Transition{
 	uint8_t 		OutputState;
 	condition_cb 	Condition;
 	bool   			*ConditionVar;
+	bool			TimedTransition = false;
 	FSM_Transition	*nextTransition = nullptr;
 } ;
 
@@ -72,6 +73,7 @@ public:
 
 	uint8_t 	AddTransition(uint8_t inputState, uint8_t outputState, condition_cb condition);
 	uint8_t 	AddTransition(uint8_t inputState, uint8_t outputState, bool &condition);
+	uint8_t		AddTimedTransition(uint8_t inputState, uint8_t outputState);
 
 	uint8_t 	AddAction(uint8_t inputState, uint8_t type, bool &target, uint32_t _time=0);
 	uint8_t 	GetState() const;

--- a/src/YA_FSM.h
+++ b/src/YA_FSM.h
@@ -25,7 +25,7 @@ struct FSM_Action{
 struct FSM_Transition{
 	uint8_t 		InputState;
 	uint8_t 		OutputState;
-	condition_cb 	Condition;
+	condition_cb 	Condition = nullptr;
 	bool   			*ConditionVar;
 	bool			TimedTransition = false;
 	FSM_Transition	*nextTransition = nullptr;


### PR DESCRIPTION
To simplify transitions based on the state's MAXTIME field and avoid the complexity involved in lambda functions inside the `AddTransition` call, I created an `AddTimedTransition()` method which performs the `_currentState->timeout` boolean check inside `Update()`. 

For clarity, this adds a bool `TimedTransition` flag (and thus, one byte per transition) inside the FSM_Transition structure; if that is wasteful, we could probably overload `Condition` and `ConditionVar` (maybe if they are both null?.

Thank you for considering! 