### PR TITLE
Update YA_FSM.cpp

### DIFF
--- a/src/YA_FSM.cpp
+++ b/src/YA_FSM.cpp
@@ -186,23 +186,23 @@ bool YA_FSM::Update()
 		{
 			bool _trigger = false;
 
-			// If a max time was defined check if current state is on timeout
-			if (m_currentState->maxTime)
-			{
-				m_currentState->timeout = millis() - m_currentState->enterTime > m_currentState->maxTime;
-				// Trigger transition on timeout
-				if (m_currentState->timeout)
-					_trigger = true;
-			}
-
 			// Trigger transition on callback function result if defined
-			else if (actualtr->Condition != nullptr)
+			if (actualtr->Condition != nullptr)
 				_trigger = actualtr->Condition();
 
 			// Trigger transition on bool variable value == true
 			else if (actualtr->ConditionVar != nullptr)
 				_trigger = *(actualtr->ConditionVar);
 
+			// If a max time was defined check if current state is on timeout
+			else if (m_currentState->maxTime)
+			{
+				m_currentState->timeout = millis() - m_currentState->enterTime > m_currentState->maxTime;
+				// Trigger transition on timeout
+				if (m_currentState->timeout)
+					_trigger = true;
+			}
+			
 			if (_trigger)
 			{
 				// Check if state is on at least from minTime


### PR DESCRIPTION
Proposing a change of order of transition checks.

If you for example have two transitions, e.g.

  stateMachine.AddTimedTransition(OPENING, ALARM);
  stateMachine.AddTransition(OPENING, OPENED, [](){return digitalRead(3) == HIGH;});

With the original code, the timed transition will always take precedence and will either go from OPENING -> ALARM or OPENING -> OPENED after x milliseconds depending on the order of definitions of the statemachine transitions. Irrelevent of which one it was meant to go per the timed transition definition. The callback defined transition is completely ignored.

This happens because the time out state is not tied to the FSM_Transition object, and was instead tied to the State itself, so it was checked and ran on every FSM_Transition first, and will cause a timeout triggered swich to whichever Transition is defined first. 

Ideally timeout could be linked to the FSM_Transition object, but given lack of purpose as far as I can see, for having multiple Timeout transitions on one state (as one would always trigger, the longer one would never) 

I've found this fix to work fine for my application. I don't believe it should cause issues for any other properly implemented systems?

You can see the issue and the fix here:
- note original and fixed headers at top to try the fix.
- note lines 41-43 to show issues with ordering of transitions with original code.

https://wokwi.com/projects/363021015658056705



